### PR TITLE
Add a flag to remove key on exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,15 @@ Usage:
   -i, --interval=300: announce interval
   -n, --name="": node name. will default to hostname.
   -p, --prefix="/queensland": etcd prefix
+        --remove=false: remove key on exit
   -t, --ttl=0: announce ttl.  0 disables
   ```
 
 In general, you would run this as a service on every node.
+
+The record, by default, is not removed on exit, but relies on the
+ttl. Using the `--remove` flag will attempt to remove the key when the
+process exits.
 
 You could use `etcdctl` or `curl` to set the same data if desired. The
 "node mode" is a convenience as it ensures proper namespacing and data
@@ -96,6 +101,7 @@ $ queensland help announce
   -n, --name="": node name. will default to hostname.
   -o, --port=0: announce service port
   -p, --prefix="/queensland": etcd prefix
+        --remove=false: remove key on exit
   -r, --priority=0: announce service priority
   -t, --ttl=60: announce ttl. 0 disables
   -w, --weight=0: announce service weight
@@ -107,9 +113,9 @@ A service announcement can optionally call a check command:
 And it will only put the key when this command returns 0. The check
 command is ran using "sh -c".
 
-Currently, the record is not removed when queensland exits or the
-check fails - it relies only on the ttl. This behavior is subject to
-change and/or will be controlled via command line flags.
+The record, by default, is not removed on exit, but relies on the
+ttl. Using the `--remove` flag will attempt to remove the key when the
+process exits.
 
 You could use `etcdctl` or `curl` to set the same data if desired. The
 "announce mode" is a convenience as it ensures proper namespacing and data

--- a/announce.go
+++ b/announce.go
@@ -65,6 +65,8 @@ func runAnnounce(cmd *cobra.Command, args []string) {
 		etcd:     etcd.NewClient(([]string{etcdAddress})),
 	}
 
+	handleRemoveOnExit(a.etcd, a.Path)
+
 	a.announce()
 	for _ = range time.Tick(a.Interval) {
 		a.announce()

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	nodeIP           string
 	nodeName         string
 	nodeTTL          uint
+	removeOnExit     bool
 )
 
 func main() {
@@ -76,6 +77,7 @@ func main() {
 	cmdAnnounce.PersistentFlags().UintVarP(&announcePriority, "priority", "r", 0, "announce service priority")
 	cmdAnnounce.PersistentFlags().UintVarP(&announceTTL, "ttl", "t", 60, "announce ttl. 0 disables")
 	cmdAnnounce.PersistentFlags().UintVarP(&announceWeight, "weight", "w", 0, "announce service weight")
+	cmdAnnounce.PersistentFlags().BoolVarP(&removeOnExit, "remove", "", false, "remove key on exit")
 
 	cmdNode := &cobra.Command{
 		Use:   "node",
@@ -87,6 +89,7 @@ func main() {
 	cmdNode.PersistentFlags().UintVarP(&nodeInterval, "interval", "i", 300, "announce interval")
 	cmdNode.PersistentFlags().StringVarP(&nodeName, "name", "n", "", "node name. will default to hostname.")
 	cmdNode.PersistentFlags().StringVarP(&nodeIP, "address", "a", "", "node addresses. will default to first non-localhost IP")
+	cmdNode.PersistentFlags().BoolVarP(&removeOnExit, "remove", "", false, "remove key on exit")
 
 	root.AddCommand(
 		cmdServer,

--- a/node.go
+++ b/node.go
@@ -52,6 +52,8 @@ func runNode(cmd *cobra.Command, args []string) {
 		Data: string(data),
 	}
 
+	handleRemoveOnExit(a.etcd, a.Path)
+
 	a.announce()
 	for _ = range time.Tick(time.Duration(nodeInterval) * time.Second) {
 		a.announce()

--- a/util.go
+++ b/util.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	etcdErr "github.com/coreos/etcd/error"
 	"github.com/coreos/go-etcd/etcd"
@@ -60,4 +63,20 @@ func getNodeName() (string, error) {
 
 	return strings.ToLower(nodeName), nil
 
+}
+
+func handleRemoveOnExit(e *etcd.Client, key string) {
+	if removeOnExit {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			for _ = range c {
+				_, err := e.Delete(key, false)
+				if err != nil {
+					log.Printf("delete of '%s' failed: %s", key, err)
+				}
+				os.Exit(0)
+			}
+		}()
+	}
 }


### PR DESCRIPTION
Includes doc updates.

This adds a flag that will try to remove the key when the process exits. The delete can fail and no retry is attempted.
