### PR TITLE
only ipv4 is currently supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Queensland also provides _helpers_ for node and service announcement.
 
 Queensland is still under heavy development.
 
+Currently, only IPv4 addresses are supported.
+
 # Installation
 
 `go get github.com/mistifyio/queensland`

--- a/util.go
+++ b/util.go
@@ -45,6 +45,10 @@ func getNodeIP() (net.IP, error) {
 		return nil, fmt.Errorf("failed to parse address: %s", nodeIP)
 	}
 
+	// XXX: we currently only correctly handle v4
+	if ip.To4() == nil {
+		return nil, fmt.Errorf("not an ipv4 address: %s", nodeIP)
+	}
 	return ip, nil
 
 }

--- a/util.go
+++ b/util.go
@@ -29,6 +29,9 @@ func getNodeIP() (net.IP, error) {
 				// log error?
 				continue
 			}
+			if ip.To4() == nil {
+				continue
+			}
 			if ip.IsGlobalUnicast() {
 				nodeIP = ip.String()
 				break


### PR DESCRIPTION
v6 addresses get munged into incorrect v4 addresses otherwise.
