### PR TITLE
server: add ".nodes." to target field in SRV responses

### DIFF
--- a/server.go
+++ b/server.go
@@ -164,7 +164,7 @@ func (s *server) ServicesSRV(w dns.ResponseWriter, r *dns.Msg, name string) (*dn
 
 		target := strings.ToLower(record.Target)
 		if !strings.Contains(target, ".") {
-			target = strings.Join([]string{target, s.domain}, ".")
+			target = strings.Join([]string{target, "nodes", s.domain}, ".")
 			isNode = true
 			// should we make sure it exists before we add it?
 		}


### PR DESCRIPTION
Without the ".nodes." clients will not be able resolve the target
if SRV was called with the equivalent of `dig +shore SRV $req`.
